### PR TITLE
Bump link to Linux deb to v0.7.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
           <img src="img/Windows 10.png" class="icon" />
           <p>Windows</p>
         </a>
-        <a href="https://github.com/qwerty-fr/qwerty-fr/releases/download/v0.7.1/qwerty-fr_0.7.1_linux.deb" class="button">
+        <a href="https://github.com/qwerty-fr/qwerty-fr/releases/download/v0.7.2/qwerty-fr_0.7.2_linux.deb" class="button">
           <img src="img/Linux.png" class="icon" />
           <p>Linux</p>
         </a>


### PR DESCRIPTION
v0.7.1 creates problems on Linux and was superseded by v0.7.2.